### PR TITLE
Insert tweet, case, & vax counts to poller

### DIFF
--- a/apps/covid_cases/test/test_helper.exs
+++ b/apps/covid_cases/test/test_helper.exs
@@ -1,3 +1,9 @@
+Application.load(:covid_cases)
+
+for app <- Application.spec(:covid_cases, :applications) do
+  Application.ensure_all_started(app)
+end
+
 ExUnit.start()
 
 Mox.defmock(CovidCases.CDCAPI.MockClient, for: CovidCases.CDCAPI)

--- a/apps/covid_daily_tweets/lib/covid_daily_tweets.ex
+++ b/apps/covid_daily_tweets/lib/covid_daily_tweets.ex
@@ -4,10 +4,10 @@ defmodule CovidDailyTweets do
 
     def configure() do
       ExTwitter.configure(
-        [consumer_key: "MHFLCbfyjRdoEHXFSVQBbA4ra",
-          consumer_secret: "dHcs4a5YPtxED6slugac7J4en4DIrrO5rVSVzaGGCalJGSBIqh",
-          access_token: "525695574-g9FJnRheNd2M4T55NHnphoCRPM6PAhNsz7Kcsrcs",
-          access_token_secret: "9c7XIXjI7ls7KYXLebeCl7lrObWbnollOWnsIw5hnvXwU"])
+        [consumer_key: "",
+          consumer_secret: "",
+          access_token: "",
+          access_token_secret: ""])
     end
 
     def getYesterdayDenver() do

--- a/apps/covid_daily_tweets/lib/covid_daily_tweets.ex
+++ b/apps/covid_daily_tweets/lib/covid_daily_tweets.ex
@@ -4,10 +4,10 @@ defmodule CovidDailyTweets do
 
     def configure() do
       ExTwitter.configure(
-        [consumer_key: "",
-          consumer_secret: "",
-          access_token: "",
-          access_token_secret: ""])
+        [consumer_key: "MHFLCbfyjRdoEHXFSVQBbA4ra",
+          consumer_secret: "dHcs4a5YPtxED6slugac7J4en4DIrrO5rVSVzaGGCalJGSBIqh",
+          access_token: "525695574-g9FJnRheNd2M4T55NHnphoCRPM6PAhNsz7Kcsrcs",
+          access_token_secret: "9c7XIXjI7ls7KYXLebeCl7lrObWbnollOWnsIw5hnvXwU"])
     end
 
     def getYesterdayDenver() do
@@ -79,7 +79,7 @@ defmodule CovidDailyTweets do
       for x <- getDailyTweets(keyword) do
         x.statuses |>
           Enum.filter(fn x -> dateTimeIsYesterday(parseTime(x.created_at)) end) |>
-          Enum.map(fn x -> %{time: parseTime(x.created_at), name: x.user.name, screen_name: x.user.screen_name, profile_image_url: x.user.profile_image_url_https, text: x.text, hashtags: getHashtag(x.entities.hashtags), retweet_count: x.retweet_count} end)
+          Enum.map(fn x -> %{time: parseTime(x.created_at), name: x.user.name, screen_name: x.user.screen_name, profile_image_url: x.user.profile_image_url_https, text: x.text, hashtags: getHashtag(x.entities.hashtags), retweet_count: x.retweet_count, label: String.to_atom(keyword <> "_tweets")} end)
       end |>
         List.flatten()
     end
@@ -87,7 +87,9 @@ defmodule CovidDailyTweets do
     def tweetcount_yesterday(tweetdata) do
       #Get tweet count from tweet data
 
-      length(tweetdata)
+      count = length(tweetdata)
+
+      %{date: getYesterdayDenver(), count: count, label: List.first(tweetdata).label}
     end
 
     def common_hashtags_yesterday(tweetdata) do
@@ -95,7 +97,7 @@ defmodule CovidDailyTweets do
 
       excludedHashtags = ["", "VACCINE", "VACCINATION", "COVID", "COVID19", "COVID_19", "COVIDVACCINE", "CORONAVIRUS"]
 
-      tweetdata |>
+      hashtags = tweetdata |>
         Enum.map(fn x -> x.hashtags end) |>
         List.flatten() |>
         Enum.map(fn x -> String.downcase(x) end) |>
@@ -104,6 +106,8 @@ defmodule CovidDailyTweets do
         Enum.filter(fn {_k, v} -> v > 1 end) |>
         Enum.sort_by(&elem(&1, 1), :desc) |>
         Enum.map(fn x -> "#" <> elem(x,0) <> " " <> "(" <> to_string(elem(x, 1)) <> ")" end)
+
+        %{date: getYesterdayDenver(), hashtags: hashtags, label: List.first(tweetdata).label}
     end
 
     def most_retweeted_yesterday(tweetdata) do

--- a/apps/covid_daily_tweets/test/test_helper.exs
+++ b/apps/covid_daily_tweets/test/test_helper.exs
@@ -1,1 +1,7 @@
+Application.load(:covid_daily_tweets)
+
+for app <- Application.spec(:covid_daily_tweets, :applications) do
+  Application.ensure_all_started(app)
+end
+
 ExUnit.start()

--- a/apps/covid_tweets/test/test_helper.exs
+++ b/apps/covid_tweets/test/test_helper.exs
@@ -1,1 +1,7 @@
+Application.load(:covid_tweets)
+
+for app <- Application.spec(:covid_tweets, :applications) do
+  Application.ensure_all_started(app)
+end
+
 ExUnit.start()

--- a/apps/covid_tweets_web/test/test_helper.exs
+++ b/apps/covid_tweets_web/test/test_helper.exs
@@ -1,3 +1,9 @@
+Application.load(:covid_tweets_web)
+Application.ensure_all_started(:covid_tweets_web)
+for app <- Application.spec(:covid_tweets_web, :applications) do
+  Application.ensure_all_started(app)
+end
+
 ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(Data.Repo, :manual)

--- a/apps/covid_vaccines/test/test_helper.exs
+++ b/apps/covid_vaccines/test/test_helper.exs
@@ -1,3 +1,9 @@
+Application.load(:covid_vaccines)
+
+for app <- Application.spec(:covid_vaccines, :applications) do
+  Application.ensure_all_started(app)
+end
+
 ExUnit.start()
 
 Mox.defmock(CovidVaccines.CSVReader.MockReader, for: CovidVaccines.CSVReader)

--- a/apps/data/lib/data.ex
+++ b/apps/data/lib/data.ex
@@ -57,4 +57,11 @@ defmodule Data do
     changeset = Data.DailyCount.changeset(%Data.DailyCount{}, params)
     Data.Repo.insert(changeset)
   end
+
+
+  # Insert list of hashtags.
+  def insert_hashtags(params) do
+    changeset = Data.Hashtag.changeset(%Data.Hashtag{}, params)
+    Data.Repo.insert(changeset)
+  end
 end

--- a/apps/data/lib/data/hashtag.ex
+++ b/apps/data/lib/data/hashtag.ex
@@ -1,0 +1,16 @@
+defmodule Data.Hashtag do
+  use Ecto.Schema
+
+  schema "hashtags" do
+    field :date, :date
+    field :hashtags, {:array, :string}
+    field :label, Ecto.Enum, values: [:covid_tweets, :vaccine_tweets]
+  end
+
+  def changeset(hashtag, params \\ %{}) do
+    hashtag
+    |> Ecto.Changeset.cast(params, [:date, :hashtags, :label])
+    |> Ecto.Changeset.validate_required([:date, :hashtags, :label])
+    |> Ecto.Changeset.validate_inclusion(:label, [:covid_tweets, :vaccine_tweets])
+  end
+end

--- a/apps/data/lib/data/tweet.ex
+++ b/apps/data/lib/data/tweet.ex
@@ -9,11 +9,13 @@ defmodule Data.Tweet do
     field :text, :string
     field :hashtags, {:array, :string}
     field :retweet_count, :integer
+    field :label, Ecto.Enum, values: [:covid_tweets, :vaccine_tweets]
   end
 
   def changeset(tweet, params \\ %{}) do
     tweet
-    |> Ecto.Changeset.cast(params, [:time, :name, :screen_name, :profile_image_url, :text, :hashtags, :retweet_count])
-    |> Ecto.Changeset.validate_required([:time, :name, :screen_name, :profile_image_url, :text, :hashtags, :retweet_count])
+    |> Ecto.Changeset.cast(params, [:time, :name, :screen_name, :profile_image_url, :text, :hashtags, :retweet_count, :label])
+    |> Ecto.Changeset.validate_required([:time, :name, :screen_name, :profile_image_url, :text, :hashtags, :retweet_count, :label])
+    |> Ecto.Changeset.validate_inclusion(:label, [:covid_tweets, :vaccine_tweets])
   end
 end

--- a/apps/data/priv/repo/migrations/20210409170503_edit_tweets.exs
+++ b/apps/data/priv/repo/migrations/20210409170503_edit_tweets.exs
@@ -1,0 +1,9 @@
+defmodule Data.Repo.Migrations.EditTweets do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tweets) do
+      add :label, :string
+    end
+  end
+end

--- a/apps/data/priv/repo/migrations/20210409172813_create_hashtags.exs
+++ b/apps/data/priv/repo/migrations/20210409172813_create_hashtags.exs
@@ -1,0 +1,11 @@
+defmodule Data.Repo.Migrations.CreateHashtags do
+  use Ecto.Migration
+
+  def change do
+    create table(:hashtags) do
+      add :date, :date
+      add :hashtags, {:array, :string}
+      add :label, :string
+    end
+  end
+end

--- a/apps/data/test/data_tweet_test.exs
+++ b/apps/data/test/data_tweet_test.exs
@@ -13,7 +13,8 @@ defmodule DataTweetTest do
       profile_image_url: "https://www.testdomain.com/image.png",
       text: "Test tweet.",
       hashtags: ["#covid19", "#another"],
-      retweet_count: 12
+      retweet_count: 12,
+      label: :covid_tweets
     }
 
     # Insert tweet
@@ -27,6 +28,7 @@ defmodule DataTweetTest do
     assert ret.text == tweet.text
     assert ret.hashtags == tweet.hashtags
     assert ret.retweet_count == tweet.retweet_count
+    assert ret.label == tweet.label
 
     # Retrieve tweet
     query = from t in Data.Tweet,
@@ -43,6 +45,7 @@ defmodule DataTweetTest do
       assert q_tweet.text == tweet.text
       assert q_tweet.hashtags == tweet.hashtags
       assert q_tweet.retweet_count == tweet.retweet_count
+      assert q_tweet.label == tweet.label
   end
 
   test "error on inserting tweet with missing data" do
@@ -54,7 +57,8 @@ defmodule DataTweetTest do
       profile_image_url: "https://www.testdomain.com/image.png",
       # Missing text
       hashtags: ["#covid19", "#another"],
-      retweet_count: 12
+      retweet_count: 12,
+      label: :covid_tweets
     }
 
     # Insert tweet

--- a/apps/data/test/test_helper.exs
+++ b/apps/data/test/test_helper.exs
@@ -1,3 +1,9 @@
+Application.load(:data)
+Application.ensure_all_started(:data)
+for app <- Application.spec(:data, :applications) do
+  Application.ensure_all_started(app)
+end
+
 ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(Data.Repo, :manual)

--- a/apps/pollers/lib/pollers/tweet_poller.ex
+++ b/apps/pollers/lib/pollers/tweet_poller.ex
@@ -22,8 +22,23 @@ defmodule Pollers.TweetPoller do
         tweetcount_covid = tweetdata_covid.counts
         tweetcount_vaccine = tweetdata_vaccine.counts
 
-        Data.insert_daily_count(%{date: yesterday, label: :covid_tweets, count: tweetcount_covid})
-        Data.insert_daily_count(%{date: yesterday, label: :vaccine_tweets, count: tweetcount_vaccine})
+        toptweets_covid = tweetdata_covid.retweeteds
+        toptweets_vaccine = tweetdata_vaccine.retweeteds
+
+        hashtags_covid = tweetdata_covid.hashtags
+        hashtags_vaccine = tweetdata_vaccine.hashtags
+
+        #Insert tweets counts
+        Data.insert_daily_count(tweetcount_covid)
+        Data.insert_daily_count(tweetcount_vaccine)
+
+        #Insert top tweets
+        Enum.each(toptweets_covid, fn (tweet) -> Data.insert_tweet(tweet) end)
+        Enum.each(toptweets_vaccine, fn (tweet) -> Data.insert_tweet(tweet) end)
+
+        #Insert top hashtags
+        Data.insert_hashtags(hashtags_covid)
+        Data.insert_hashtags(hashtags_vaccine)
     end
 
     if findwork_covid_cases() do

--- a/apps/pollers/mix.exs
+++ b/apps/pollers/mix.exs
@@ -26,7 +26,10 @@ defmodule Pollers.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:data, in_umbrella: true} # depends on the Data app for persistence
+      {:data, in_umbrella: true}, # depends on the Data app for persistence
+      {:covid_daily_tweets, in_umbrella: true},
+      {:covid_cases, in_umbrella: true},
+      {:covid_vaccines, in_umbrella: true},
     ]
   end
 end

--- a/apps/pollers/test/test_helper.exs
+++ b/apps/pollers/test/test_helper.exs
@@ -1,1 +1,7 @@
+Application.load(:pollers)
+
+for app <- Application.spec(:pollers, :applications) do
+  Application.ensure_all_started(app)
+end
+
 ExUnit.start()

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule CovidTweets.Umbrella.MixProject do
     [
       # run `mix setup` in all child apps
       setup: ["cmd mix setup"],
-      test: ["ecto.drop --quiet", "ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.drop --quiet", "ecto.create --quiet", "ecto.migrate", "test --no-start"]
     ]
   end
 end


### PR DESCRIPTION
Added to `Pollers.TweetPoller` code to (1) first check if tweet, case, or vaccine count data for yesterday/day-before-yesterday is already in the database and, if not, (2) fetch an insert it.