### PR TITLE
Graphs3

### DIFF
--- a/apps/covid_tweets_web/assets/css/app.scss
+++ b/apps/covid_tweets_web/assets/css/app.scss
@@ -126,6 +126,7 @@ body {
 
 .switch_button {
   width: 10%;
+  margin-top: 40px;
   margin-left: auto;
   margin-right: auto;
   display: block;

--- a/apps/covid_tweets_web/assets/css/app.scss
+++ b/apps/covid_tweets_web/assets/css/app.scss
@@ -123,3 +123,10 @@ body {
   margin-right: auto;
   width: 50%;
 }
+
+.switch_button {
+  width: 10%;
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}

--- a/apps/covid_tweets_web/lib/covid_tweets_web/live/page_live.ex
+++ b/apps/covid_tweets_web/lib/covid_tweets_web/live/page_live.ex
@@ -12,6 +12,8 @@ defmodule CovidTweetsWeb.PageLive do
 
   @impl true
   def handle_event("change_date_covid", %{"start_date" => start_date, "end_date" => end_date}, socket) do
+    # cast to Dates from strings
+    {{_, start_date}, {_, end_date}} = {Date.from_iso8601(start_date), Date.from_iso8601(end_date)}
     {tweet_dates, tweet_counts} = query_database(start_date, end_date, :covid_tweets)
     {covid_dates, covid_counts} = query_database(start_date, end_date, :covid_cases)
 
@@ -23,20 +25,54 @@ defmodule CovidTweetsWeb.PageLive do
   end
 
   @impl true
-  def handle_event("change_date_vaccine", %{"start_date" => start_date, "end_date" => end_date}, socket) do    
+  def handle_event("change_date_vaccine", %{"start_date" => start_date, "end_date" => end_date}, socket) do
+    # cast to Dates from strings
+    {{_, start_date}, {_, end_date}} = {Date.from_iso8601(start_date), Date.from_iso8601(end_date)} 
     {tweet_dates, tweet_counts} = query_database(start_date, end_date, :vaccine_tweets)
     {vaccine_dates, vaccine_counts} = query_database(start_date, end_date, :vaccine_counts)
 
-    if vaccine_dates != tweet_dates do
-      raise "Data mismatch: at least one day only vaccines counts or twitter counts. This function requires that for each day either none or both have data."
-    end    
+    tweet_dates = Enum.map(tweet_dates, fn x -> Date.from_iso8601(x) |> elem(1) end)
+    vaccine_dates = Enum.map(vaccine_dates, fn x -> Date.from_iso8601(x) |> elem(1) end)
+    full_date_set = Enum.map(0..Date.diff(end_date, start_date), &Date.add(start_date, &1))
 
-    {:noreply, socket |> push_event("update_vaccine_chart", %{dates: tweet_dates, vaccine_counts: vaccine_counts, tweet_counts: tweet_counts})}
+    IO.inspect(vaccine_counts)
+
+    {vaccine_dates, vaccine_counts} = if length(full_date_set) > length(vaccine_dates) do
+      # IO.inspect("Data mismatch #{length(full_date_set)} > #{length(vaccine_dates)}: attempting to fix...")
+      {vaccine_dates, vaccine_counts} = fix_data_mismatch(vaccine_dates, vaccine_counts, full_date_set, 0)
+      # if length(full_date_set) != length(vaccine_counts) do
+      #   IO.inspect("Data mismatch unresolved: #{length(full_date_set)} != #{length(vaccine_counts)}")
+      #   raise "Data mismatch: unable to be fixed"
+      # else
+      #   IO.inspect("Data mismatch resolved: #{length(full_date_set)} == #{length(vaccine_counts)}")
+      # end
+      else
+        {vaccine_dates, vaccine_counts}
+    end
+
+    {tweet_dates, tweet_counts} = if length(full_date_set) > length(tweet_dates) do
+      # IO.inspect("Data mismatch #{length(full_date_set)} > #{length(tweet_dates)}: attempting to fix...")
+      {tweet_dates, tweet_counts} = fix_data_mismatch(tweet_dates, tweet_counts, full_date_set, 0)
+      # if length(full_date_set) != length(tweet_counts) do
+      #   IO.inspect("Data mismatch unresolved: #{length(full_date_set)} != #{length(tweet_counts)}")
+      #   raise "Data mismatch: unable to be fixed"
+      # else
+      #   IO.inspect("Data mismatch resolved: #{length(full_date_set)} == #{length(tweet_counts)}")
+      # end
+      else
+        {tweet_dates, tweet_counts}
+    end
+
+
+    # IO.inspect("????")
+    # IO.inspect(tweet_dates)
+    # IO.inspect(vaccine_dates)
+    # IO.inspect(full_date_set)
+
+    {:noreply, socket |> push_event("update_vaccine_chart", %{dates: full_date_set, vaccine_counts: vaccine_counts, tweet_counts: tweet_counts})}
   end
 
   def query_database(start_date, end_date, label) do
-    # cast to Dates from strings
-    {{_, start_date}, {_, end_date}} = {Date.from_iso8601(start_date), Date.from_iso8601(end_date)}
     # query database
     query = from dc in Data.DailyCount, 
       where: dc.date >= ^start_date and dc.date <= ^end_date and dc.label == ^label,
@@ -47,5 +83,51 @@ defmodule CovidTweetsWeb.PageLive do
     counts = Enum.reduce(results, [], fn x, acc -> acc ++ [x[:count]] end)
     {dates, counts}
   end
+
+  def fix_data_mismatch(dates, data, all_dates, index) do
+    
+    cond do
+      # Base case
+      length(dates) == length(all_dates) ->
+        {dates, data}
+      # Missing dates at the end of the list
+      index >= length(dates) and index < length(all_dates)->
+        {dates, data} = insert_missing(dates, data, all_dates, index)
+        {dates, data} = fix_data_mismatch(dates, data, all_dates, index)
+      # Missing a data point. Fill in a date/data
+      Date.compare(Enum.at(dates, index), Enum.at(all_dates, index)) == :gt ->
+        {dates, data} = insert_missing(dates, data, all_dates, index)
+        {dates, data} = fix_data_mismatch(dates, data, all_dates, index)
+      # Dates lines up, do nothing and move on to next index
+      Date.compare(Enum.at(dates, index), Enum.at(all_dates, index)) == :eq ->
+        {dates, data} = fix_data_mismatch(dates, data, all_dates, index + 1)
+      # true -> 
+      #   IO.inspect("All dates: #{Enum.at(all_dates, index)}, fetched datese: #{Enum.at(dates, index)}")
+      #   raise "no conda is true"
+    end
+  end
+
+  def insert_missing(dates_to_fill, data_to_fill, all_dates, index) do
+    # IO.inspect("input dates:")
+    # IO.inspect(dates_to_fill)
+    # IO.inspect(data_to_fill)
+    dates_filled = List.insert_at(dates_to_fill, index, Enum.at(all_dates, index))
+    # Zero fill
+    data_filled = data_filled = List.insert_at(data_to_fill, index, 0)
+    # interpolate
+    if False do
+      val = 0
+      if index > 0 and index < length(data_to_fill) do
+        val = div(Enum.at(data_to_fill, index - 1) + Enum.at(data_to_fill, index), 2)
+      end
+      data_filled = List.insert_at(data_to_fill, index, val)
+    end
+    # IO.inspect("output")
+    # IO.inspect(dates_filled)
+    # IO.inspect(data_filled)
+    {dates_filled, data_filled}
+  end
+
+
 
 end

--- a/apps/covid_tweets_web/lib/covid_tweets_web/live/page_live.ex
+++ b/apps/covid_tweets_web/lib/covid_tweets_web/live/page_live.ex
@@ -101,7 +101,8 @@ defmodule CovidTweetsWeb.PageLive do
     data_filled = if interpolate do
       # Interpolate
       val = cond do 
-        index > 0 and index < length(data_to_fill) -> div(Enum.at(data_to_fill, index - 1) + Enum.at(data_to_fill, index), 2)
+        index > 0 and index < length(data_to_fill) -> 
+          Enum.at(data_to_fill, index - 1) + div(Enum.at(data_to_fill, index - 1) - Enum.at(data_to_fill, index), Date.diff(Enum.at(dates_to_fill, index-1), Enum.at(dates_to_fill, index)))
         index > 0 -> Enum.at(data_to_fill, index - 1)
         index < length(data_to_fill) -> Enum.at(data_to_fill, index)
         true -> 0

--- a/apps/covid_tweets_web/lib/covid_tweets_web/live/page_live.html.leex
+++ b/apps/covid_tweets_web/lib/covid_tweets_web/live/page_live.html.leex
@@ -39,4 +39,8 @@
       <input type="submit" value="Update Chart">
     </form>
   </div>
+
+  <div class="switch_button">
+    <button class="button" data-csrf="csrf_token" data-method="get" data-to="/">Back to Tweets</button>
+  </div>
 </div>

--- a/apps/covid_tweets_web/lib/covid_tweets_web/templates/page/index.html.eex
+++ b/apps/covid_tweets_web/lib/covid_tweets_web/templates/page/index.html.eex
@@ -11,3 +11,7 @@
     <% end %>
   </div>
 </div>
+
+<div class="switch_button">
+    <button class="button" data-csrf="csrf_token" data-method="get" data-to="/graphs">To Graphs</button>
+</div>

--- a/apps/covid_tweets_web/lib/tweet_count_test_data_generator.ex
+++ b/apps/covid_tweets_web/lib/tweet_count_test_data_generator.ex
@@ -3,7 +3,7 @@ defmodule CovidTweetsWeb.TweetCountTestDataGenerator do
   import Ecto.Query, only: [from: 2]
 
 
-  defmodule AddCounts do
+  defmodule MatchedData do
     def add_count(date, n) do
       # Covid tweet count insertion
       count = round(:math.cos(n / :math.pi) * 1000 + 1000)
@@ -56,10 +56,77 @@ defmodule CovidTweetsWeb.TweetCountTestDataGenerator do
     end
   end
 
-  def generate() do
-    AddCounts.add_count_loop(Date.from_iso8601("2021-03-01") |> elem(1), 0)
+  defmodule MismatchedData do
+    def add_count(date, n) do
+      if rem(n, 4) == 0 do
+        # Covid tweet count insertion
+        count = round(:math.cos(n / :math.pi) * 1000 + 1000)
+        covid_count = %{
+          date: Date.add(date, n),
+          label: :covid_tweets,
+          count: count
+        }
+        changeset = Data.DailyCount.changeset(%Data.DailyCount{}, covid_count)
+        {:ok, _} = Data.Repo.insert(changeset)
+      end
+
+      if rem(n, 4) == 1 do
+        # Covid case count insertion
+        count = round(:math.sin(n / :math.pi) * 100 + 100)
+        covid_count = %{
+          date: Date.add(date, n),
+          label: :covid_cases,
+          count: count
+        }
+        changeset = Data.DailyCount.changeset(%Data.DailyCount{}, covid_count)
+        {:ok, _} = Data.Repo.insert(changeset)
+      end
+
+      if rem(n, 4) == 2 do
+        # Vaccine Tweet count insertion
+        count = round(:math.cos(n / :math.pi) * 500 + 500)
+        covid_count = %{
+          date: Date.add(date, n),
+          label: :vaccine_tweets,
+          count: count
+        }
+        changeset = Data.DailyCount.changeset(%Data.DailyCount{}, covid_count)
+        {:ok, _} = Data.Repo.insert(changeset)
+      end
+
+      if rem(n, 4) == 3 do
+        # Vaccine count insertion
+        count = round(:math.sin(n / :math.pi) * 50 + 50)
+        covid_count = %{
+          date: Date.add(date, n),
+          label: :vaccine_counts,
+          count: count
+        }
+        changeset = Data.DailyCount.changeset(%Data.DailyCount{}, covid_count)
+        {:ok, _} = Data.Repo.insert(changeset)
+      end
+    end
+
+    def add_count_loop(date, n) when n == 100 do
+      add_count(date, n)
+    end
+
+    def add_count_loop(date, n) do
+      add_count(date, n)
+      add_count_loop(date, n+1)
+    end
+  end
+
+  def generate_matched() do
+    MatchedData.add_count_loop(Date.from_iso8601("2021-03-01") |> elem(1), 0)
+  end
+
+  def generate_mismatched() do
+    MismatchedData.add_count_loop(Date.from_iso8601("2021-03-01") |> elem(1), 0)
   end
 end
 
 # To use this script, first call `iex -S mix` then:
-# CovidTweetsWeb.TweetCountTestDataGenerator.generate()
+# CovidTweetsWeb.TweetCountTestDataGenerator.generate_matched()
+# OR
+# CovidTweetsWeb.TweetCountTestDataGenerator.generate_mismatched()


### PR DESCRIPTION
Add zero-filling and interpolation to allow for missing data points. Currently set to linear interpolation. For zero-filling, change the flag on line 100 of page_live.ex. This PR also adds buttons to go back and forth between the tweet page and the graphs page. A test data generator that generates data with missing data points for this is also included in tweet_count_test_data_generator.ex (see the bottom of the file for how to use it.